### PR TITLE
Typo 'node' instead of 'type'

### DIFF
--- a/sql/create-triggered-table.sql
+++ b/sql/create-triggered-table.sql
@@ -25,7 +25,7 @@ OPTIONS
     (
         host '127.0.0.1',
         port '9200',
-        node 'test',
+        type 'test',
         index 'articles'
     )
 ;


### PR DESCRIPTION
A small typo in SQL examples