### PR TITLE
Added option use_ssl.

### DIFF
--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -63,6 +63,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
             ],
             http_auth=auth,
             timeout=int(options.get("timeout", "10")),
+            use_ssl=options.get("use_ssl", False),
         )
 
         self.columns = columns


### PR DESCRIPTION
Hi, first of all, thanks for the wrapper! It has helped simplify our setup greatly :smile: 

Our Elasticsearch connection requires SSL to be enabled. I created a fork that exposes the use_ssl flag to the options.

Note: I have barely any experience in Python, so maybe don't accept this pull request:sweat_smile: 

Ideally, you should be able to set all options that can be passed to Elasticsearch. Maybe a JSON that is simply passed down to Elasticsearch? I dunno.

This works for us though.