### PR TITLE
tests: Add trust auth for all pg versions

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   postgres:
     build:
       context: ../../
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     links:
       - elasticsearch
     ports:

--- a/tests/docker/pg-12/docker-compose.yml
+++ b/tests/docker/pg-12/docker-compose.yml
@@ -6,5 +6,3 @@ services:
       dockerfile: ./tests/docker/pg-12/Dockerfile
     image: pg-es-fdw:pg-12-es-${ES_VERSION}
     container_name: pg-12
-    environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
I had this error running tests:

```
docker logs pg-9.4
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

So I added `POSTGRES_HOST_AUTH_METHOD=trust` environment variable to the common docker-compose.yml