### PR TITLE
WIP: Add refresh parameter to insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ If you always want sorted results then you can use the `default_sort` option to 
 To break ties you can specify further columns to sort on.
 You just need to separate the columns with a comma, for example `unit:asc,last_updated:desc`.
 
+```
+SELECT
+    id,
+    title,
+    body,
+    metadata,
+    score
+FROM
+    articles_es
+WHERE
+    sort = 'id:asc'
+;
+```
+
 Caveats
 -------
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ CREATE FOREIGN TABLE articles_es
         body TEXT,
         metadata JSON,
         query TEXT,
-        score NUMERIC
+        score NUMERIC,
+        sort TEXT
     )
 SERVER multicorn_es
 OPTIONS
@@ -99,6 +100,8 @@ OPTIONS
         rowid_column 'id',
         query_column 'query',
         score_column 'score',
+        default_sort 'last_updated:desc',
+        sort_column 'sort',
         timeout '20',
         username 'elastic',
         password 'changeme'
@@ -115,6 +118,7 @@ fields. The other fields have special meaning:
  * The `id` field is mapped to the Elastic Search document id
  * The `query` field accepts Elastic Search queries to filter the rows
  * The `score` field returns the score for the document against the query
+ * The `sort` field accepts an Elastic Search column to sort by
  * The `timeout` field specifies the connection timeout in seconds
  * The `username` field specifies the basic auth username used
  * The `password` field specifies the basic auth password used
@@ -199,79 +203,17 @@ WHERE
 
 This uses the [URI Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) from Elastic Search.
 
-#### Using the default sort and sort column
+#### Sorting the Results
 
-Example: Creating the table
-```
-CREATE FOREIGN TABLE test_index (
-    id TEXT,
-    unit TEXT,
-    name TEXT,
-    last_updated timestamp,
-    address TEXT,
-    ipv4 TEXT,
-    company TEXT,
-    credit_card_number TEXT,
-    credit_card_provider TEXT,
-    credit_card_security TEXT,
-    email TEXT,
-    query TEXT,
-    sort TEXT,
-    score NUMERIC
- )
-SERVER multicorn_es
-OPTIONS (
-    host 'localhost',
-    port '9200',
-    index 'test-index',
-    type 'doc',
-    rowid_column 'id',
-    query_column 'query',
-    score_column 'score',
-    default_sort 'last_updated:desc',
-    sort_column 'sort',
-    timeout '20'
- );
-```
+By default Elastic Search returns the documents in score order, descending.
+If you wish to sort by a different field you can use the `sort_column` option.
 
-Not using the sort column in the where clause, as you see it uses the default setting.
+The `sort_column` accepts a column to sort by and a direction, for example `last_updated:desc`.
+This is passed to Elastic Search so it should be the name of the Elastic Search column.
+If you always want sorted results then you can use the `default_sort` option to specify the sort when creating the table.
 
-```
-test=# select unit,last_updated,sort from test_index limit 10;
-NOTICE:  Sort: last_updated:desc
- unit |        last_updated        |       sort
-------+----------------------------+-------------------
- 2426 | 2020-09-25 09:47:33.490236 | last_updated:desc
- 2425 | 2020-09-25 09:47:32.477546 | last_updated:desc
- 2424 | 2020-09-25 09:47:31.469799 | last_updated:desc
- 2423 | 2020-09-25 09:47:30.463913 | last_updated:desc
- 2422 | 2020-09-25 09:47:29.456766 | last_updated:desc
- 2421 | 2020-09-25 09:47:28.445883 | last_updated:desc
- 2420 | 2020-09-25 09:47:27.427684 | last_updated:desc
- 2419 | 2020-09-25 09:47:26.414521 | last_updated:desc
- 2418 | 2020-09-25 09:47:25.404088 | last_updated:desc
- 2417 | 2020-09-25 09:47:24.396159 | last_updated:desc
-```
-
-Using the column to sort by other means. can be a comma seperated list
-```
-unit:asc,last_updated:desc
-```
-```
-test=# select unit,last_updated,sort from test_index WHERE sort = 'unit:asc' limit 10;
- unit |        last_updated        |   sort
-------+----------------------------+----------
- 0    | 2020-09-25 09:06:42.353452 | unit:asc
- 1    | 2020-09-25 09:06:43.367991 | unit:asc
- 2    | 2020-09-25 09:06:44.379327 | unit:asc
- 3    | 2020-09-25 09:06:45.389997 | unit:asc
- 4    | 2020-09-25 09:06:46.403873 | unit:asc
- 5    | 2020-09-25 09:06:47.41339  | unit:asc
- 6    | 2020-09-25 09:06:48.421894 | unit:asc
- 7    | 2020-09-25 09:06:49.433148 | unit:asc
- 8    | 2020-09-25 09:06:50.445831 | unit:asc
- 9    | 2020-09-25 09:06:51.457017 | unit:asc
-```
+To break ties you can specify further columns to sort on.
+You just need to separate the columns with a comma, for example `unit:asc,last_updated:desc`.
 
 Caveats
 -------

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Not using the sort column in the where clause, as you see it uses the default se
 ```
 test=# select unit,last_updated,sort from test_index limit 10;
 NOTICE:  Sort: last_updated:desc
- unit |        last_updated        |       sort        
+ unit |        last_updated        |       sort
 ------+----------------------------+-------------------
  2426 | 2020-09-25 09:47:33.490236 | last_updated:desc
  2425 | 2020-09-25 09:47:32.477546 | last_updated:desc
@@ -259,7 +259,7 @@ unit:asc,last_updated:desc
 ```
 ```
 test=# select unit,last_updated,sort from test_index WHERE sort = 'unit:asc' limit 10;
- unit |        last_updated        |   sort   
+ unit |        last_updated        |   sort
 ------+----------------------------+----------
  0    | 2020-09-25 09:06:42.353452 | unit:asc
  1    | 2020-09-25 09:06:43.367991 | unit:asc

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -40,8 +40,8 @@ class ElasticsearchFDW(ForeignDataWrapper):
         username = options.pop("username", None)
         password = options.pop("password", None)
 
-        self.refresh = options.pop("refresh", False)
-        if self.refresh not in {True, False, "wait_for"}:
+        self.refresh = options.pop("refresh", "false").lower()
+        if self.refresh not in {"true", "false", "wait_for"}:
             raise ValueError("refresh option must be one of true, false, or wait_for")
         self.complete_returning = options.pop("complete_returning", False)
 

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -73,6 +73,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
             for column in columns.values()
             if column.base_type_name.upper() in {"JSON", "JSONB"}
         }
+        self.scroll_id = None
 
     def get_rel_size(self, quals, columns):
         """ Helps the planner by returning costs.
@@ -116,7 +117,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
                 )
 
             while True:
-                scroll_id = response["_scroll_id"]
+                self.scroll_id = response["_scroll_id"]
 
                 for result in response["hits"]["hits"]:
                     yield self._convert_response_row(result, columns, query, sort)
@@ -124,7 +125,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
                 if len(response["hits"]["hits"]) < self.scroll_size:
                     return
                 response = self.client.scroll(
-                    scroll_id=scroll_id, scroll=self.scroll_duration
+                    scroll_id=self.scroll_id, scroll=self.scroll_duration
                 )
         except Exception as exception:
             log2pg(
@@ -134,6 +135,12 @@ class ElasticsearchFDW(ForeignDataWrapper):
                 logging.ERROR,
             )
             return
+
+    def end_scan(self):
+        """ Hook called at the end of a foreign scan. """
+        if self.scroll_id:
+            self.client.clear_scroll(scroll_id=self.scroll_id)
+            self.scroll_id = None
 
     def insert(self, new_values):
         """ Insert new documents into Elastic Search """

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -157,9 +157,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
             response = self.client.index(
                 id=document_id, body=new_values, refresh=self.refresh, **self.arguments
             )
-            data = {}
-            data[self.rowid_column] = response["_id"]
-            return data
+            return {self.rowid_column: response["_id"]}
         except Exception as exception:
             log2pg(
                 "INDEX for {path}/{document_id} and document {document} failed: {exception}".format(

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -277,7 +277,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         try:
             arguments = dict(self.arguments)
             results = self.client.search(
-                body={"query": {"ids": {"values": [row_id]}}}, size=10000, **arguments
+                body={"query": {"ids": {"values": [row_id]}}}, **arguments
             )["hits"]["hits"]
             if results:
                 return self._convert_response_row(results[0], self.columns, None, None)

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -43,7 +43,9 @@ class ElasticsearchFDW(ForeignDataWrapper):
         self.refresh = options.pop("refresh", "false").lower()
         if self.refresh not in {"true", "false", "wait_for"}:
             raise ValueError("refresh option must be one of true, false, or wait_for")
-        self.complete_returning = options.pop("complete_returning", False)
+        self.complete_returning = (
+            options.pop("complete_returning", "false").lower() == "true"
+        )
 
         if ELASTICSEARCH_VERSION[0] >= 7:
             self.path = "/{index}".format(index=self.index)

--- a/tests/data/schema.sql
+++ b/tests/data/schema.sql
@@ -39,6 +39,34 @@ OPTIONS
     )
 ;
 
+
+CREATE FOREIGN TABLE articles_es_wait_for
+    (
+        id BIGINT,
+        title TEXT,
+        body TEXT,
+        query TEXT,
+        sort TEXT,
+        score NUMERIC
+    )
+SERVER multicorn_es
+OPTIONS
+    (
+        host 'elasticsearch',
+        port '9200',
+        index 'article-index',
+        type 'article',
+        rowid_column 'id',
+        query_column 'query',
+        sort_column 'sort',
+        score_column 'score',
+        timeout '20',
+        username 'elastic',
+        password 'changeme',
+        refresh 'wait_for'
+    )
+;
+
 CREATE FOREIGN TABLE nested_articles_es
     (
         id BIGINT,

--- a/tests/data/schema.sql
+++ b/tests/data/schema.sql
@@ -39,7 +39,6 @@ OPTIONS
     )
 ;
 
-
 CREATE FOREIGN TABLE articles_es_wait_for
     (
         id BIGINT,
@@ -64,6 +63,34 @@ OPTIONS
         username 'elastic',
         password 'changeme',
         refresh 'wait_for'
+    )
+;
+
+CREATE FOREIGN TABLE articles_es_returning
+    (
+        id BIGINT,
+        title TEXT,
+        body TEXT,
+        query TEXT,
+        sort TEXT,
+        score NUMERIC
+    )
+SERVER multicorn_es
+OPTIONS
+    (
+        host 'elasticsearch',
+        port '9200',
+        index 'article-index',
+        type 'article',
+        rowid_column 'id',
+        query_column 'query',
+        sort_column 'sort',
+        score_column 'score',
+        timeout '20',
+        username 'elastic',
+        password 'changeme',
+        refresh 'wait_for',
+        complete_returning 'true'
     )
 ;
 

--- a/tests/lib/test.py
+++ b/tests/lib/test.py
@@ -55,7 +55,19 @@ def perform_tests(pg_version, es_version):
 
     show_status("Testing insert returning id...")
     data, error = run_sql_test("insert-return-id.sql")
-    if not show_result(pg_version, es_version, "insert returning id", (data == '1', error)):
+    if not show_result(
+        pg_version, es_version, "insert returning id", (data == "1", error)
+    ):
+        success = False
+
+    show_status("Testing insert returning row...")
+    data, error = run_sql_test("insert-return-row.sql")
+    if not show_result(
+        pg_version,
+        es_version,
+        "insert returning row",
+        (data == "2 | Test insert wait for title | test insert wait for body", error),
+    ):
         success = False
 
     show_status("Testing insert waiting for refresh...")
@@ -64,7 +76,7 @@ def perform_tests(pg_version, es_version):
         pg_version,
         es_version,
         "insert waiting for refresh",
-        (data == '2 | Test insert wait for title | test insert wait for body', error)
+        (data == "2 | Test insert wait for title | test insert wait for body", error),
     ):
         success = False
 

--- a/tests/lib/test.py
+++ b/tests/lib/test.py
@@ -53,6 +53,21 @@ def perform_tests(pg_version, es_version):
     if not show_result(pg_version, es_version, "query", run_sql_test("query.sql")):
         success = False
 
+    show_status("Testing insert returning id...")
+    data, error = run_sql_test("insert-return-id.sql")
+    if not show_result(pg_version, es_version, "insert returning id", (data == '1', error)):
+        success = False
+
+    show_status("Testing insert waiting for refresh...")
+    data, error = run_sql_test("insert-wait_for.sql")
+    if not show_result(
+        pg_version,
+        es_version,
+        "insert waiting for refresh",
+        (data == '2 | Test insert wait for title | test insert wait for body', error)
+    ):
+        success = False
+
     return success
 
 

--- a/tests/lib/test.py
+++ b/tests/lib/test.py
@@ -66,7 +66,7 @@ def perform_tests(pg_version, es_version):
         pg_version,
         es_version,
         "insert returning row",
-        (data == "2 | Test insert wait for title | test insert wait for body", error),
+        (data == "2 | Test insert title | test insert body", error),
     ):
         success = False
 
@@ -76,7 +76,7 @@ def perform_tests(pg_version, es_version):
         pg_version,
         es_version,
         "insert waiting for refresh",
-        (data == "2 | Test insert wait for title | test insert wait for body", error),
+        (data == "3 | Test insert wait for title | test insert wait for body", error),
     ):
         success = False
 

--- a/tests/lib/test.py
+++ b/tests/lib/test.py
@@ -66,7 +66,7 @@ def perform_tests(pg_version, es_version):
         pg_version,
         es_version,
         "insert returning row",
-        (data == "2 | Test insert title | test insert body", error),
+        (data == "2 | Test insert returning title | test insert returning body", error),
     ):
         success = False
 

--- a/tests/test/insert-return-id.sql
+++ b/tests/test/insert-return-id.sql
@@ -1,0 +1,2 @@
+INSERT INTO articles_es (id, title, body)
+VALUES (1, 'Test insert title', 'test insert body') RETURNING id;

--- a/tests/test/insert-return-row.sql
+++ b/tests/test/insert-return-row.sql
@@ -1,2 +1,2 @@
 INSERT INTO articles_es_returning (id, title, body)
-VALUES (1, 'Test insert title', 'test insert body') RETURNING id, title, body;
+VALUES (2, 'Test insert title', 'test insert body') RETURNING id, title, body;

--- a/tests/test/insert-return-row.sql
+++ b/tests/test/insert-return-row.sql
@@ -1,0 +1,2 @@
+INSERT INTO articles_es_returning (id, title, body)
+VALUES (1, 'Test insert title', 'test insert body') RETURNING id, title, body;

--- a/tests/test/insert-return-row.sql
+++ b/tests/test/insert-return-row.sql
@@ -1,2 +1,2 @@
 INSERT INTO articles_es_returning (id, title, body)
-VALUES (2, 'Test insert title', 'test insert body') RETURNING id, title, body;
+VALUES (2, 'Test insert returning title', 'test insert returning body') RETURNING id, title, body;

--- a/tests/test/insert-wait_for.sql
+++ b/tests/test/insert-wait_for.sql
@@ -1,7 +1,7 @@
 WITH
 inserted AS (
   INSERT INTO articles_es_wait_for (id, title, body)
-  VALUES (2, 'Test insert wait for title', 'test insert wait for body') RETURNING id
+  VALUES (3, 'Test insert wait for title', 'test insert wait for body') RETURNING id
 )
 SELECT es.id, es.title, es.body FROM inserted
 LEFT JOIN articles_es_wait_for as es ON es.id = inserted.id;

--- a/tests/test/insert-wait_for.sql
+++ b/tests/test/insert-wait_for.sql
@@ -1,0 +1,7 @@
+WITH
+inserted AS (
+  INSERT INTO articles_es_wait_for (id, title, body)
+  VALUES (2, 'Test insert wait for title', 'test insert wait for body') RETURNING id
+)
+SELECT es.id, es.title, es.body FROM inserted
+LEFT JOIN articles_es_wait_for as es ON es.id = inserted.id;


### PR DESCRIPTION
related to #13 

- Add return of the document id after insert (and related test)
- Add `refresh` parameter
  - can be `True`, `wait_for` or `False`, default and fallback to `False`
  - add to `es.index`