### PR TITLE
Add Query DSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ OPTIONS
         type 'article',
         rowid_column 'id',
         query_column 'query',
+        query_dsl 'false',
         score_column 'score',
         default_sort 'last_updated:desc',
         sort_column 'sort',
@@ -119,6 +120,7 @@ fields. The other fields have special meaning:
 
  * The `rowid_column` (`id` above) is mapped to the Elastic Search document id
  * The `query_column` (`query` above) accepts Elastic Search queries to filter the rows
+ * The `query_dsl` (`false` above) indicates if the query is in the [URI Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) syntax or the json [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html). The query will use the URI Search syntax by default. To use the Query DSL set this option to `"true"`.
  * The `score_column` (`score` above) returns the score for the document against the query
  * The `sort_column` (`sort` above) accepts an Elastic Search column to sort by
  * The `refresh` option controls if inserts and updates should wait for an index refresh ([Elastic Search documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html)). The acceptable values are `"false"` (default), `"wait_for"` and `"true"`
@@ -188,7 +190,9 @@ FROM
 ;
 ```
 
-To filter the documents using a query:
+##### URI Search Query
+
+To filter the documents using a URI Search query:
 
 ```sql
 SELECT
@@ -205,6 +209,29 @@ WHERE
 ```
 
 This uses the [URI Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html) from Elastic Search.
+This is the default search syntax, and can be explicitly selected by setting the `query_dsl` option to `"false"`.
+
+##### Query DSL Query
+
+To filter the documents using a Query DSL query you must ensure that you have set the `query_dsl` option to `"true"` when creating the table.
+
+```sql
+SELECT
+    id,
+    title,
+    body,
+    metadata,
+    score
+FROM
+    articles_es
+WHERE
+    query = '{"query":{"bool":{"filter":[{"term":{"body":"chess"}}]}}}'
+;
+```
+
+This uses the [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) from Elastic Search.
+This is not the default search syntax and must be specifically enabled.
+You cannot enable this on a per-query basis.
 
 #### Sorting the Results
 

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -31,6 +31,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         self.index = options.pop("index", "")
         self.doc_type = options.pop("type", "")
         self.query_column = options.pop("query_column", None)
+        self.is_json_query = options.pop("json_query", "false").lower() == "true"
         self.score_column = options.pop("score_column", None)
         self.default_sort = options.pop("default_sort", "")
         self.sort_column = options.pop("sort_column", None)
@@ -77,7 +78,6 @@ class ElasticsearchFDW(ForeignDataWrapper):
             if column.base_type_name.upper() in {"JSON", "JSONB"}
         }
         self.scroll_id = None
-        self.is_json_query = self.query_column in self.json_columns
 
     def get_rel_size(self, quals, columns):
         """ Helps the planner by returning costs.

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -31,7 +31,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         self.index = options.pop("index", "")
         self.doc_type = options.pop("type", "")
         self.query_column = options.pop("query_column", None)
-        self.is_json_query = options.pop("json_query", "false").lower() == "true"
+        self.is_json_query = options.pop("query_dsl", "false").lower() == "true"
         self.score_column = options.pop("score_column", None)
         self.default_sort = options.pop("default_sort", "")
         self.sort_column = options.pop("sort_column", None)

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -77,7 +77,6 @@ class ElasticsearchFDW(ForeignDataWrapper):
             if column.base_type_name.upper() in {"JSON", "JSONB"}
         }
         self.scroll_id = None
-        self.json_query = self.query_column in self.json_columns
 
     def get_rel_size(self, quals, columns):
         """ Helps the planner by returning costs.
@@ -86,7 +85,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         try:
             query = self._get_query(quals)
             if query:
-                response = self.client.count(**query, **self.arguments)
+                response = self.client.count(q=query, **self.arguments)
             else:
                 response = self.client.count(**self.arguments)
             return (response["count"], len(columns) * 100)
@@ -112,7 +111,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
                 response = self.client.search(
                     size=self.scroll_size,
                     scroll=self.scroll_duration,
-                    **query,
+                    q=query,
                     **arguments
                 )
             else:
@@ -234,7 +233,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         if not self.query_column:
             return None
 
-        result = next(
+        return next(
             (
                 qualifier.value
                 for qualifier in quals
@@ -242,9 +241,6 @@ class ElasticsearchFDW(ForeignDataWrapper):
             ),
             None,
         )
-        if self.json_query:
-            return {"body": result}
-        return {"q": result}
 
     def _get_sort(self, quals):
         if not self.sort_column:
@@ -268,8 +264,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
             or column == self.score_column
         }
         if query:
-            query_value = next(iter(query.values()))
-            return_dict[self.query_column] = query_value
+            return_dict[self.query_column] = query
         return_dict[self.sort_column] = sort
         return return_dict
 

--- a/tests/data/schema.sql
+++ b/tests/data/schema.sql
@@ -138,7 +138,7 @@ OPTIONS
         type 'article',
         rowid_column 'id',
         query_column 'query',
-        json_query 'true',
+        query_dsl 'true',
         sort_column 'sort',
         score_column 'score',
         timeout '20',

--- a/tests/data/schema.sql
+++ b/tests/data/schema.sql
@@ -120,4 +120,32 @@ OPTIONS
     )
 ;
 
+CREATE FOREIGN TABLE articles_es_json_query
+    (
+        id BIGINT,
+        title TEXT,
+        body TEXT,
+        query TEXT,
+        sort TEXT,
+        score NUMERIC
+    )
+SERVER multicorn_es
+OPTIONS
+    (
+        host 'elasticsearch',
+        port '9200',
+        index 'article-index',
+        type 'article',
+        rowid_column 'id',
+        query_column 'query',
+        json_query 'true',
+        sort_column 'sort',
+        score_column 'score',
+        timeout '20',
+        username 'elastic',
+        password 'changeme'
+    )
+;
+
+
 \q

--- a/tests/lib/test.py
+++ b/tests/lib/test.py
@@ -53,6 +53,13 @@ def perform_tests(pg_version, es_version):
     if not show_result(pg_version, es_version, "query", run_sql_test("query.sql")):
         success = False
 
+    show_status("Testing json query...")
+    data, error = run_sql_test("json-query.sql")
+    if not show_result(
+        pg_version, es_version, "json-query", (data == "Portal Chess", error)
+    ):
+        success = False
+
     show_status("Testing insert returning id...")
     data, error = run_sql_test("insert-return-id.sql")
     if not show_result(

--- a/tests/test/json-query.sql
+++ b/tests/test/json-query.sql
@@ -1,0 +1,7 @@
+SELECT
+    title
+FROM
+    articles_es_json_query
+WHERE
+    query = '{"query":{"bool":{"filter":[{"term":{"body":"chess"}}]}}}'
+;


### PR DESCRIPTION
Fixes https://github.com/matthewfranglen/postgres-elasticsearch-fdw/issues/19

The query column must remain TEXT as there is no operator support for JSON equality tests. The equality test is required to prevent the FDW from filtering all the rows on return.